### PR TITLE
Docs: Add Project Architecture Overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ Use it on web, and soon — on WhatsApp & mobile apps too!
 
 Smriti AI is built on a modern, modular stack to handle conversational AI tasks efficiently. The core components work together as follows:
 
-- **🌐 FastAPI:** Serves as the high-performance web framework for the API server. It handles all incoming HTTP requests, manages endpoints (e.g., `/upload`, `/chat`), and returns responses. All server-side logic is located in the `smriti_ai/server/` directory.
+- 🖥️ **Streamlit:** Serves as the web app framework that creates the user interface. It is responsible for displaying the chat window, handling file uploads, and managing user interaction. The main application logic can be found in `app.py`.
 
-- **🧠 LlamaIndex:** This is the core data framework that powers the Retrieval-Augmented Generation (RAG) pipeline. It is responsible for:
+- 🧠 **LlamaIndex:** This is the core data framework that powers the Retrieval-Augmented Generation (RAG) pipeline. It is responsible for:
   - **Data Ingestion:** Processing and chunking documents and websites.
   - **Indexing:** Creating vector embeddings from the data chunks.
   - **Querying:** Finding the most relevant context from the knowledge base to answer a user's question.
 
-- **💾 Qdrant:** Acts as the specialized vector database. When documents are indexed, the resulting vector embeddings are stored in Qdrant. Its job is to perform ultra-fast similarity searches to retrieve the context that LlamaIndex needs to formulate an answer.
+- 💾 **Qdrant:** Acts as the specialized vector database. When documents are indexed, the resulting vector embeddings are stored in Qdrant. Its job is to perform ultra-fast similarity searches to retrieve the context that LlamaIndex needs to formulate an answer.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ See how much you’ve improved over time, identify weak areas, and never lose tr
 💬 **Multimodal Interface**  
 Use it on web, and soon — on WhatsApp & mobile apps too!
 
+## Project Architecture
+
+Smriti AI is built on a modern, modular stack to handle conversational AI tasks efficiently. The core components work together as follows:
+
+- **🌐 FastAPI:** Serves as the high-performance web framework for the API server. It handles all incoming HTTP requests, manages endpoints (e.g., `/upload`, `/chat`), and returns responses. All server-side logic is located in the `smriti_ai/server/` directory.
+
+- **🧠 LlamaIndex:** This is the core data framework that powers the Retrieval-Augmented Generation (RAG) pipeline. It is responsible for:
+  - **Data Ingestion:** Processing and chunking documents and websites.
+  - **Indexing:** Creating vector embeddings from the data chunks.
+  - **Querying:** Finding the most relevant context from the knowledge base to answer a user's question.
+
+- **💾 Qdrant:** Acts as the specialized vector database. When documents are indexed, the resulting vector embeddings are stored in Qdrant. Its job is to perform ultra-fast similarity searches to retrieve the context that LlamaIndex needs to formulate an answer.
+
 ---
 
 ## 👥 Who Is It For?


### PR DESCRIPTION
Closes #<32>

Description

This pull request addresses the need for better architectural documentation for new contributors. It adds a new "Project Architecture" section to the README.md file.

Changes Made

[x] Added a new ## Project Architecture section to README.md.

[x] Provided a brief, high-level overview of the roles of FastAPI, LlamaIndex, and Qdrant in the project.

[x] Included emojis and formatting to improve readability.

This enhancement will help lower the barrier to entry for GSSoC participants and other new contributors by making the project's structure easier to understand at a glance.