### PR TITLE
Fix: make navbar logo responsive on smaller screens

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -9,10 +9,10 @@ export default function Navbar() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
-          <div className="flex items-center w-1/5">
+          <div className="flex items-center w-auto sm:w-1/5 flex-shrink-0">
             <Link
               href="/#"
-              className="flex items-center cursor-pointer hover:opacity-90 transition-all duration-300 group"
+              className="flex items-center cursor-pointer hover:opacity-90 transition-all duration-300 group whitespace-nowrap"
             >
               <Brain className="me-[5px] h-5 w-5 text-[#adff2f]" />
               <span className="text-xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 dark:from-white dark:to-gray-300 bg-clip-text text-transparent group-hover:from-[#adff2f] group-hover:to-[#9dff07] transition-all duration-300">


### PR DESCRIPTION
## Fixes #74 

## Description
This PR addresses an issue where the header logo breaks or becomes distorted on smaller screen sizes (e.g., Galaxy S8+). The update ensures the logo scales proportionally, maintaining its aspect ratio, and does not disrupt the layout.

## Before
<img width="399" height="594" alt="478334976-cb441494-5eb6-4489-88f1-27b421e5a210" src="https://github.com/user-attachments/assets/a02514b8-a8f8-45e6-abe1-1374f2673831" />

## After
<img width="315" height="480" alt="Screenshot 2025-08-15 212030" src="https://github.com/user-attachments/assets/82e94cc4-4fe5-44dd-a9b7-63ee21abd6bf" />

<img width="300" height="480" alt="Screenshot 2025-08-15 212051" src="https://github.com/user-attachments/assets/fd17c710-e8bb-4378-898c-d43b9335600e" />
