### PR TITLE
feat: option to add notes

### DIFF
--- a/app/(authenticated_Pages)/dashboard/topic/[[...id]]/page.tsx
+++ b/app/(authenticated_Pages)/dashboard/topic/[[...id]]/page.tsx
@@ -1,9 +1,12 @@
+// app/(authenticated_Pages)/dashboard/topic/[[...id]]/page.tsx
+
 "use client";
 
 import { use } from "react";
 import { useRouter } from "next/navigation";
 import { PlusCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"; // Import Tabs
 import TopicHeader from "@/components/topic/TopicHeader";
 import TopicModal from "@/components/topic/TopicModal";
 import ResourceGrid from "@/components/topic/ResourceGrid";
@@ -12,6 +15,7 @@ import DeleteDialog from "@/components/topic/DeleteDialog";
 import SearchBar from "@/components/topic/SearchBar";
 import { useTopic } from "@/hooks/useTopic";
 import { useResources } from "@/hooks/useResources";
+import { SimpleNoteEditor } from "@/components/notes/SimpleNoteEditor"; // Import our new editor
 
 export default function TopicPage({ params }: { params: any }) {
   const rawId = (use(params) as { id: string | string[] }).id;
@@ -88,51 +92,59 @@ export default function TopicPage({ params }: { params: any }) {
           topicName={topicName}
           onClick={() => setTopicModalOpen(true)}
         />
-
         <Button onClick={() => setResourceModalOpen(true)} className="gap-2">
           <PlusCircle className="h-4 w-4" />
           Add Resource
         </Button>
       </div>
+      
+      {/* --- ADD TABS TO ORGANIZE CONTENT --- */}
+      <Tabs defaultValue="resources" className="w-full">
+        <TabsList className="grid w-full grid-cols-2 max-w-md">
+          <TabsTrigger value="resources">Resources</TabsTrigger>
+          <TabsTrigger value="notes">Notes</TabsTrigger>
+        </TabsList>
 
-      {/* Resource Modal */}
-      <ResourceModal
-        open={resourceModalOpen}
-        setOpen={setResourceModalOpen}
-        resourceType={newResourceType}
-        setResourceType={setNewResourceType}
-        youtubeUrl={youtubeUrl}
-        setYoutubeUrl={setYoutubeUrl}
-        pdfTitle={pdfTitle}
-        setPdfTitle={setPdfTitle}
-        setPdfFile={setPdfFile}
-        onAdd={handleAddResource}
-        isLoading={isLoading}
-        pdfFile={pdfFile}
-      />
-
-      {/* Delete Confirmation Dialog */}
-      <DeleteDialog
-        open={deleteDialogOpen}
-        onOpenChange={setDeleteDialogOpen}
-        resourceTitle={resourceToDelete?.title || ""}
-        onDelete={handleDeleteResource}
-        isDeleting={isDeleting}
-      />
-
-      {/* Search Bar */}
-      {media.length > 0 && <SearchBar value={search} onChange={setSearch} />}
-
-      {/* Resource Grid */}
-      <ResourceGrid
-        isLoading={isLoading}
-        media={filteredMedia}
-        onResourceClick={handleResourceClick}
-        onDeleteClick={(item) => {
-          setResourceToDelete(item);
-          setDeleteDialogOpen(true);
-        }}
-      />
+        {/* Resources Tab Content (Existing Code) */}
+        <TabsContent value="resources" className="mt-4">
+          <ResourceModal
+            open={resourceModalOpen}
+            setOpen={setResourceModalOpen}
+            resourceType={newResourceType}
+            setResourceType={setNewResourceType}
+            youtubeUrl={youtubeUrl}
+            setYoutubeUrl={setYoutubeUrl}
+            pdfTitle={pdfTitle}
+            setPdfTitle={setPdfTitle}
+            setPdfFile={setPdfFile}
+            onAdd={handleAddResource}
+            isLoading={isLoading}
+            pdfFile={pdfFile}
+          />
+          <DeleteDialog
+            open={deleteDialogOpen}
+            onOpenChange={setDeleteDialogOpen}
+            resourceTitle={resourceToDelete?.title || ""}
+            onDelete={handleDeleteResource}
+            isDeleting={isDeleting}
+          />
+          {media.length > 0 && <SearchBar value={search} onChange={setSearch} />}
+          <ResourceGrid
+            isLoading={isLoading}
+            media={filteredMedia}
+            onResourceClick={handleResourceClick}
+            onDeleteClick={(item) => {
+              setResourceToDelete(item);
+              setDeleteDialogOpen(true);
+            }}
+          />
+        </TabsContent>
+        
+        {/* Notes Tab Content (New Feature) */}
+        <TabsContent value="notes" className="mt-4">
+          <SimpleNoteEditor topicId={id} />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/app/api/notes/[topicId]/route.ts
+++ b/app/api/notes/[topicId]/route.ts
@@ -1,0 +1,94 @@
+// app/api/notes/[topicId]/route.ts
+
+import { auth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+import db from "@/lib/prisma";
+
+// Helper function to get topicId from the URL
+function getTopicIdFromUrl(url: string): string | null {
+  try {
+    const parts = new URL(url).pathname.split('/');
+    // The topicId will be the last part of the URL, e.g., /api/notes/[topicId]
+    return parts[parts.length - 1];
+  } catch (error) {
+    return null;
+  }
+}
+
+export async function GET(
+  req: Request,
+  // We no longer need the 'params' argument here
+) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    // FIX: Get topicId directly from the request URL
+    const topicId = getTopicIdFromUrl(req.url);
+    if (!topicId) {
+        return new NextResponse("Invalid topic ID in URL", { status: 400 });
+    }
+
+    const topicOwner = await db.topic.findUnique({
+      where: { id: topicId, userId: userId },
+    });
+
+    if (!topicOwner) {
+      return new NextResponse("Forbidden", { status: 403 });
+    }
+
+    const note = await db.note.findUnique({
+      where: { topicId: topicId },
+    });
+
+    return NextResponse.json(note);
+  } catch (error) {
+    console.error("[GET_NOTE_API]", error);
+    return new NextResponse("Internal Server Error", { status: 500 });
+  }
+}
+
+export async function PATCH(
+  req: Request,
+   // We no longer need the 'params' argument here
+) {
+  try {
+    const { userId } = await auth();
+    const { content } = await req.json();
+
+    if (!userId) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+    
+    // FIX: Get topicId directly from the request URL
+    const topicId = getTopicIdFromUrl(req.url);
+    if (!topicId) {
+        return new NextResponse("Invalid topic ID in URL", { status: 400 });
+    }
+
+    const topicOwner = await db.topic.findUnique({
+      where: { id: topicId, userId: userId },
+    });
+
+    if (!topicOwner) {
+      return new NextResponse("Forbidden", { status: 403 });
+    }
+
+    const note = await db.note.upsert({
+      where: { topicId: topicId },
+      update: { content: content },
+      create: {
+        topicId: topicId,
+        userId: userId,
+        content: content,
+      },
+    });
+
+    return NextResponse.json(note);
+  } catch (error) {
+    console.error("[UPDATE_NOTE_API]", error);
+    return new NextResponse("Internal Server Error", { status: 500 });
+  }
+}

--- a/components/notes/SimpleNoteEditor.tsx
+++ b/components/notes/SimpleNoteEditor.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import axios from "axios";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { LoaderCircle, AlertTriangle, Edit2 } from "lucide-react";
+import { Note } from "@/types/note"; // Import the Note type
+
+export function SimpleNoteEditor({ topicId }: { topicId: string }) {
+  const [note, setNote] = useState("");
+  const [isEditing, setIsEditing] = useState(false);
+  const [status, setStatus] = useState<"loading" | "error" | "idle">("loading");
+
+  useEffect(() => {
+    const fetchNote = async () => {
+      try {
+        // FIX: Tell axios what type of data to expect
+        const response = await axios.get<Note | null>(`/api/notes/${topicId}`);
+        if (response.data?.content) {
+          setNote(response.data.content);
+        }
+      } catch (error) {
+        console.error("Failed to fetch note:", error);
+        setStatus("error");
+      } finally {
+        setStatus("idle");
+      }
+    };
+    fetchNote();
+  }, [topicId]);
+
+  const handleSave = async () => {
+    try {
+      await axios.patch(`/api/notes/${topicId}`, { content: note });
+      setIsEditing(false);
+    } catch (error) {
+      console.error("Failed to save note:", error);
+      setStatus("error");
+    }
+  };
+
+  if (status === "loading") {
+    return <div className="flex justify-center items-center h-40"><LoaderCircle className="h-8 w-8 animate-spin text-muted-foreground" /></div>;
+  }
+
+  if (status === "error") {
+    return (
+      <div className="flex flex-col justify-center items-center h-40 text-destructive bg-destructive/10 rounded-md">
+        <AlertTriangle className="h-8 w-8 mb-2" />
+        <p>Failed to load or save note. Please refresh.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 border rounded-md min-h-[200px] prose dark:prose-invert">
+      {isEditing ? (
+        <div className="flex flex-col gap-4">
+          <Textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            className="w-full min-h-[150px]"
+            placeholder="Write your notes here..."
+          />
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => setIsEditing(false)}>Cancel</Button>
+            <Button onClick={handleSave}>Save</Button>
+          </div>
+        </div>
+      ) : (
+        <div className="relative">
+          <Button variant="ghost" size="icon" onClick={() => setIsEditing(true)} className="absolute top-0 right-0">
+            <Edit2 className="h-4 w-4" />
+          </Button>
+          {note ? (
+            <p className="whitespace-pre-wrap">{note}</p>
+          ) : (
+            <p className="text-muted-foreground">No notes yet. Click the edit icon to start writing.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,14 +10,14 @@ datasource db {
 }
 
 model User {
-  id           String   @id @default(uuid())
-  username     String   @unique
-  email        String   @unique
-  mobile       String
-  dob          String
-  lastLogin    DateTime @default(now())
-  currentStreak Int     @default(0)
-  topics       Topic[]
+  id            String   @id @default(uuid())
+  username      String   @unique
+  email         String   @unique
+  mobile        String
+  dob           String
+  lastLogin     DateTime @default(now())
+  currentStreak Int      @default(0)
+  topics        Topic[]
 }
 
 model Topic {
@@ -28,6 +28,7 @@ model Topic {
   updatedAt DateTime   @updatedAt
   user      User       @relation(fields: [userId], references: [id], onDelete: Cascade)
   resources Resource[]
+  note      Note? // <-- This line is new
 }
 
 enum ResourceType {
@@ -37,15 +38,15 @@ enum ResourceType {
 }
 
 model Resource {
-  id        String     @id @default(uuid())
+  id        String       @id @default(uuid())
   topicId   String
   title     String
   type      ResourceType
   url       String
   summary   String
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
-  topic     Topic      @relation(fields: [topicId], references: [id],onDelete: Cascade)
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+  topic     Topic        @relation(fields: [topicId], references: [id], onDelete: Cascade)
   quizzes   Quiz[]
 }
 
@@ -54,7 +55,7 @@ model Quiz {
   resourceId  String       @unique
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
-  resource    Resource     @relation(fields: [resourceId], references: [id],onDelete: Cascade)
+  resource    Resource     @relation(fields: [resourceId], references: [id], onDelete: Cascade)
   quizQAs     QuizQA[]
   quizResults QuizResult[]
 }
@@ -66,7 +67,7 @@ model QuizQA {
   options       String[]
   correctAnswer String
   explanation   String?
-  quiz          Quiz     @relation(fields: [quizId], references: [id],onDelete: Cascade)
+  quiz          Quiz     @relation(fields: [quizId], references: [id], onDelete: Cascade)
 }
 
 model QuizResult {
@@ -75,7 +76,7 @@ model QuizResult {
   score     Int
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  quiz      Quiz     @relation(fields: [quizId], references: [id],onDelete: Cascade)
+  quiz      Quiz     @relation(fields: [quizId], references: [id], onDelete: Cascade)
 }
 
 model ContactQuery {
@@ -87,3 +88,14 @@ model ContactQuery {
   createdAt DateTime @default(now())
 }
 
+// v-- This entire model is new --v
+model Note {
+  id        String   @id @default(uuid())
+  content   String?  @db.Text
+  topicId   String   @unique
+  userId    String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  topic Topic @relation(fields: [topicId], references: [id], onDelete: Cascade)
+}

--- a/types/note.ts
+++ b/types/note.ts
@@ -1,0 +1,6 @@
+export type Note = {
+  id: string;
+  content: string | null;
+  topicId: string;
+  userId: string;
+};


### PR DESCRIPTION
## Summary

This pull request introduces a new **Notes** feature for topics, allowing users to write, save, and view personal notes associated with each topic they create. This provides a dedicated space for users to keep their thoughts and learnings.

The implementation focuses on stability and a clean user experience, featuring distinct "view" and "edit" modes.

## Key Features

-   **Database Schema:** A new `Note` model has been added to the `prisma.schema` and linked with a one-to-one relationship to the `Topic` model.
-   **Secure Backend API:** A new API route (`/api/notes/[topicId]`) has been created with `GET` and `PATCH` handlers.
    -   All requests are authenticated and authorized, ensuring users can only access their own notes.
    -   The `PATCH` endpoint uses Prisma's `upsert` for efficient creation and updating of notes.
-   **Frontend Component:** A new, stable component (`SimpleNoteEditor`) was built using a standard `<textarea>`.
    -   It features a **View/Edit Mode** toggle, providing a clean reading experience and a clear editing interface.
    -   State is managed with React hooks (`useState`, `useEffect`) to handle user input and interaction.

## How to Test

1.  Navigate to any topic page.
2.  Click on the new **"Notes"** tab.
3.  The note area should display "No notes yet." Click the **edit icon** in the top-right corner.
4.  The view should switch to a text area. Write a note and click **"Save"**.
5.  The view should switch back to "view mode," displaying the saved text.
6.  Refresh the page to confirm that the note is fetched and displayed correctly from the database.

## Screenrecording
[notes-demo.webm](https://github.com/user-attachments/assets/e1c1d06d-4ed8-46a0-9470-cec28921283a)
