### PR TITLE
feat: implement centralized metadata management system with page-spec…

### DIFF
--- a/app/(authenticated_Pages)/dashboard/layout.tsx
+++ b/app/(authenticated_Pages)/dashboard/layout.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next";
+import { generateMetadata } from "@/lib/metadata";
+
+export const metadata: Metadata = generateMetadata('dashboard');
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next";
+import { generateMetadata } from "@/lib/metadata";
+
+export const metadata: Metadata = generateMetadata('about');
+
+export default function AboutLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/contact/layout.tsx
+++ b/app/contact/layout.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next";
+import { generateMetadata } from "@/lib/metadata";
+
+export const metadata: Metadata = generateMetadata('contact');
+
+export default function ContactLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/contributors/layout.tsx
+++ b/app/contributors/layout.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next";
+import { generateMetadata } from "@/lib/metadata";
+
+export const metadata: Metadata = generateMetadata('contributors');
+
+export default function ContributorsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { generateMetadata } from "@/lib/metadata";
 import { Poppins } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/navbar";
@@ -13,10 +14,8 @@ const poppins = Poppins({
   weight: ["400", "500", "600", "700"],
 });
 
-export const metadata: Metadata = {
-  title: "Smriti AI",
-  description: "Smriti AI - Remember Smarter",
-};
+// Default metadata for the root layout
+export const metadata = generateMetadata('home');
 
 export default function RootLayout({
   children,

--- a/app/privacy-policy/layout.tsx
+++ b/app/privacy-policy/layout.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next";
+import { generateMetadata } from "@/lib/metadata";
+
+export const metadata: Metadata = generateMetadata('privacyPolicy');
+
+export default function PrivacyPolicyLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/sign-in/layout.tsx
+++ b/app/sign-in/layout.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next";
+import { generateMetadata } from "@/lib/metadata";
+
+export const metadata: Metadata = generateMetadata('signIn');
+
+export default function SignInLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/sign-up/layout.tsx
+++ b/app/sign-up/layout.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next";
+import { generateMetadata } from "@/lib/metadata";
+
+export const metadata: Metadata = generateMetadata('signUp');
+
+export default function SignUpLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/terms-of-use/layout.tsx
+++ b/app/terms-of-use/layout.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next";
+import { generateMetadata } from "@/lib/metadata";
+
+export const metadata: Metadata = generateMetadata('termsOfUse');
+
+export default function TermsOfUseLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,0 +1,105 @@
+import type { Metadata } from "next";
+
+type PageMetadata = {
+    title?: string;
+    description?: string;
+    keywords?: string[];
+};
+
+/**
+ * Default metadata values
+ */
+const defaultMetadata: PageMetadata = {
+    title: "Smriti AI",
+    description: "Smriti AI - Remember Smarter",
+    keywords: ["Smriti AI", "learning", "AI", "education", "study", "memory", "notes"],
+};
+
+/**
+ * Page-specific metadata configurations
+ */
+const pageMetadata: Record<string, PageMetadata> = {
+    home: {
+        title: "Smriti AI",
+        description: "Transform your learning experience with AI-powered tools that help you study smarter, retain better, and achieve academic excellence.",
+        keywords: ["Smriti AI", "learning platform", "AI education", "study tools", "memory enhancement", "academic excellence"],
+    },
+    about: {
+        title: "About Smriti AI | Our Mission & Vision",
+        description: "Learn about Smriti AI's mission to democratize learning and make quality education accessible to every learner through AI-powered tools.",
+        keywords: ["about Smriti AI", "AI education mission", "learning technology", "education accessibility", "AI learning tools"],
+    },
+    contact: {
+        title: "Contact Smriti AI | Get in Touch",
+        description: "Have questions about Smriti AI? Contact our team for support, partnership opportunities, or general inquiries.",
+        keywords: ["contact Smriti AI", "AI education support", "learning platform help", "Smriti AI contact", "education technology support"],
+    },
+    dashboard: {
+        title: "Smriti AI Dashboard | Your Learning Hub",
+        description: "Access your personalized Smriti AI dashboard to manage your learning materials, track progress, and enhance your study experience.",
+        keywords: ["Smriti AI dashboard", "learning management", "study dashboard", "AI education platform", "personalized learning"],
+    },
+    contributors: {
+        title: "Smriti AI Contributors | Our Community",
+        description: "Meet the talented developers and contributors who have helped make Smriti AI possible.",
+        keywords: ["Smriti AI contributors", "open source contributors", "AI education community", "developers", "open source project"],
+    },
+    privacyPolicy: {
+        title: "Privacy Policy | Smriti AI",
+        description: "Learn about how Smriti AI collects, uses, and protects your personal information and data.",
+        keywords: ["Smriti AI privacy policy", "data protection", "privacy terms", "user data", "information security"],
+    },
+    termsOfUse: {
+        title: "Terms of Use | Smriti AI",
+        description: "Read the terms and conditions for using Smriti AI's learning platform and services.",
+        keywords: ["Smriti AI terms", "terms of service", "user agreement", "legal terms", "usage policy"],
+    },
+    signIn: {
+        title: "Sign In | Smriti AI",
+        description: "Sign in to your Smriti AI account to access your personalized learning dashboard and tools.",
+        keywords: ["Smriti AI login", "sign in", "user account", "learning platform access"],
+    },
+    signUp: {
+        title: "Sign Up | Smriti AI",
+        description: "Create your Smriti AI account to start your journey to smarter learning and better retention.",
+        keywords: ["Smriti AI signup", "create account", "join learning platform", "new user registration"],
+    },
+};
+
+/**
+ * Generate metadata for a specific page
+ * @param pageName - The name of the page to generate metadata for
+ * @param customMetadata - Optional custom metadata to override defaults
+ * @returns Metadata object for the page
+ */
+export function generateMetadata(
+    pageName: keyof typeof pageMetadata | string,
+    customMetadata?: PageMetadata
+): Metadata {
+    // Get page-specific metadata or default to the default metadata
+    const baseMetadata = pageMetadata[pageName as keyof typeof pageMetadata] || defaultMetadata;
+
+    // Merge with any custom metadata provided
+    const mergedMetadata = {
+        ...baseMetadata,
+        ...customMetadata,
+    };
+
+    return {
+        title: mergedMetadata.title || defaultMetadata.title,
+        description: mergedMetadata.description || defaultMetadata.description,
+        keywords: mergedMetadata.keywords || defaultMetadata.keywords,
+        // Add additional metadata properties as needed
+        openGraph: {
+            title: mergedMetadata.title || defaultMetadata.title,
+            description: mergedMetadata.description || defaultMetadata.description,
+            type: "website",
+            siteName: "Smriti AI",
+        },
+        twitter: {
+            card: "summary_large_image",
+            title: mergedMetadata.title || defaultMetadata.title,
+            description: mergedMetadata.description || defaultMetadata.description,
+        },
+    };
+}


### PR DESCRIPTION
# Add Dynamic Meta Tags for SEO

## Description
This PR adds dynamic meta tags (title, description, keywords) to improve SEO and sharing on Smriti AI. Instead of hardcoded tags, we now have a simple setup that handles page-specific metadata.

## Changes
- Added a `metadata` helper in `lib/metadata.ts`
- Set up page-level titles, descriptions, and keywords
- Added OpenGraph + Twitter tags for better link previews
- Added default fallback values

## Testing
- Checked pages show the right title/description
- Verified OpenGraph and Twitter tags work
- Confirmed defaults apply when no custom data is set

## Related Issue
Closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced centralized, dynamic metadata across the site (including Home), delivering consistent titles, descriptions, keywords, and richer social sharing previews.
  * Added route-specific layouts for Dashboard, About, Contact, Contributors, Privacy Policy, Terms of Use, Sign In, and Sign Up, ensuring consistent page scaffolding and future extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->