### PR TITLE
Added card for discord in contact section

### DIFF
--- a/app/(public)/contact/page.tsx
+++ b/app/(public)/contact/page.tsx
@@ -387,42 +387,68 @@ export default function ContactPage() {
 
           {/* Additional Contact Information */}
           <motion.div className="mt-12" variants={itemVariants}>
-            <h2 className="text-2xl font-semibold text-foreground mb-6 text-center">
-              Other Ways to Reach Us
-            </h2>
-            <div className="grid md:grid-cols-2 gap-6">
-              <motion.div variants={itemVariants}>
-                <Card className="border-border/50 backdrop-blur-sm bg-background/95 hover:shadow-lg transition-all duration-200">
-                  <CardContent className="pt-6">
-                    <div className="text-center">
-                      <Mail className="w-8 h-8 mx-auto mb-3 text-primary" />
-                      <h3 className="font-semibold text-foreground mb-2">
-                        Email
-                      </h3>
-                      <p className="text-muted-foreground">
-                        support@smriti.live
-                      </p>
-                    </div>
-                  </CardContent>
-                </Card>
-              </motion.div>
-              <motion.div variants={itemVariants}>
-                <Card className="border-border/50 backdrop-blur-sm bg-background/95 hover:shadow-lg transition-all duration-200">
-                  <CardContent className="pt-6">
-                    <div className="text-center">
-                      <Clock className="w-8 h-8 mx-auto mb-3 text-primary" />
-                      <h3 className="font-semibold text-foreground mb-2">
-                        Response Time
-                      </h3>
-                      <p className="text-muted-foreground">
-                        Usually within 24 hours
-                      </p>
-                    </div>
-                  </CardContent>
-                </Card>
-              </motion.div>
-            </div>
-          </motion.div>
+  <h2 className="text-2xl font-semibold text-foreground mb-6 text-center">
+    Other Ways to Reach Us
+  </h2>
+  <div className="grid md:grid-cols-3 gap-6 items-stretch">
+    {/* Email Card */}
+    <motion.div variants={itemVariants} className="h-full">
+      <Card className="h-full border-border/50 backdrop-blur-sm bg-background/95 hover:shadow-lg transition-all duration-200">
+        <CardContent className="pt-6 flex flex-col justify-between h-full">
+          <div className="text-center">
+            <Mail className="w-8 h-8 mx-auto mb-3 text-primary" />
+            <h3 className="font-semibold text-foreground mb-2">Email</h3>
+            <p className="text-muted-foreground break-words">
+              support@smriti.live
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </motion.div>
+
+   {/* Discord Card */}
+<motion.div variants={itemVariants} className="h-full">
+  <a
+    href="https://discord.gg/tN8HNxrzp8"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="block h-full"
+  >
+    <Card className="h-full border-border/50 backdrop-blur-sm bg-background/95 hover:shadow-lg transition-all duration-200">
+      <CardContent className="pt-6 flex flex-col justify-between h-full">
+        <div className="text-center">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="w-8 h-8 mx-auto mb-3 text-primary"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+          >
+            <path d="M13.545 2.907a13.2 13.2 0 0 0-3.257-1.011.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.2 12.2 0 0 0-3.658 0 8 8 0 0 0-.412-.833.05.05 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.011a.04.04 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032q.003.022.021.037a13.3 13.3 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019q.463-.63.818-1.329a.05.05 0 0 0-.01-.059l-.018-.011a9 9 0 0 1-1.248-.595.05.05 0 0 1-.02-.066l.015-.019q.127-.095.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.05.05 0 0 1 .053.007q.121.1.248.195a.05.05 0 0 1-.004.085 8 8 0 0 1-1.249.594.05.05 0 0 0-.03.03.05.05 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019 13.2 13.2 0 0 0 4.001-2.02.05.05 0 0 0 .021-.037c.334-3.451-.559-6.449-2.366-9.106a.03.03 0 0 0-.02-.019m-8.198 7.307c-.789 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612m5.316 0c-.788 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.451.73 1.438 1.613 0 .888-.631 1.612-1.438 1.612"/>
+          </svg>
+          <h3 className="font-semibold text-foreground mb-2">Discord</h3>
+          <p className="text-muted-foreground break-words">
+            Join our community
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  </a>
+</motion.div>
+
+    {/* Response Time Card */}
+    <motion.div variants={itemVariants} className="h-full">
+      <Card className="h-full border-border/50 backdrop-blur-sm bg-background/95 hover:shadow-lg transition-all duration-200">
+        <CardContent className="pt-6 flex flex-col justify-between h-full">
+          <div className="text-center">
+            <Clock className="w-8 h-8 mx-auto mb-3 text-primary" />
+            <h3 className="font-semibold text-foreground mb-2">Response Time</h3>
+            <p className="text-muted-foreground">Usually within 24 hours</p>
+          </div>
+        </CardContent>
+      </Card>
+    </motion.div>
+  </div>
+</motion.div>
         </div>
       </div>
     </motion.div>


### PR DESCRIPTION
# Add Discord card to contact section

## Summary
Added a Discord contact card to the "Other Ways to Reach Us" section to provide users with an additional communication channel.

## Changes
- Added Discord card with icon and "Join our community" text
- Updated contact section layout to display three cards (Email, Discord, Response Time)

## Before
<img width="991" height="321" alt="image" src="https://github.com/user-attachments/assets/6ecb3e03-0443-47ef-a031-565731f2c800" />
*Contact section with only Email and Response Time cards*

## After
![WhatsApp Image 2025-08-27 at 21 46 54_2a99866c](https://github.com/user-attachments/assets/b24fdcd0-b86d-442a-a577-48a8f9038809)
*Contact section now includes Discord card in the center*

## Testing
- [x] Layout renders correctly
- [x] Responsive design maintained
- [x] Consistent styling with existing cards




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Discord card that links externally to join the community.

* **Style**
  * Reworked “Other Ways to Reach Us” into a three-card, full-height grid for consistent layout.
  * Updated Email and Response Time cards to match the new grid with uniform heights.
  * Improved email text wrapping and spacing for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->