### PR TITLE
feat(blogs): redesigned blogs page with card-based responsive layout …

### DIFF
--- a/app/(public)/blogs/page.tsx
+++ b/app/(public)/blogs/page.tsx
@@ -1,13 +1,56 @@
+import BlogCard from "@/components/blog/BlogCard";
 import Link from "next/link";
 import { getAllBlogPosts } from "@/lib/blog";
 import Footer from "@/components/Footer";
 
 export default async function BlogsPage() {
+  //the below line is commented out to use dummy data for layout testing
+  //when using real data, uncomment it
+
   const posts = await getAllBlogPosts();
+
+  //dummy posts for layout testing
+
+  // const posts = [
+  //   {
+  //     title: "Sample Blog Post",
+  //     slug: "sample-blog",
+  //     featureImage: { url: "https://via.placeholder.com/600x400" },
+  //     author: "John Doe",
+  //     publishDate: new Date().toISOString(),
+  //     summary: "This is a test excerpt for the blog layout.",
+  //   },
+  //   {
+  //     title: "Another Post",
+  //     slug: "another-post",
+  //     featureImage: { url: "https://via.placeholder.com/600x400" },
+  //     author: "Jane Smith",
+  //     publishDate: new Date().toISOString(),
+  //     summary: "Second test excerpt, to check grid responsiveness.",
+  //   },
+  // ];
+
+  //above data is dummy data for layout testing
+
   return (
     <section className="max-w-7xl mx-auto pb-32 px-6">
       <h1 className="text-3xl font-bold mb-8">Blogs</h1>
-      <div className="space-y-8">
+      {/* 1 col on mobile, 2 on md, 3 on lg+ */}
+      <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        {posts.map((post) => (
+          <BlogCard
+            key={post.slug}
+            title={post.title}
+            slug={post.slug}
+            coverImage={post.featureImage?.url}  // comes from lib/blog.ts
+            author={post.author}
+            date={post.publishDate}
+            excerpt={post.summary}
+          />
+        ))}
+      </div>
+
+      {/* <div className="space-y-8">
         {posts.map((post) => (
           <article
             key={post.slug}
@@ -31,7 +74,7 @@ export default async function BlogsPage() {
             </div>
           </article>
         ))}
-      </div>
+      </div> */}
     </section>
   );
 }

--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -1,3 +1,5 @@
+import BlogCard from "@/components/blog/BlogCard";
+
 import Hero from "@/components/landing/Hero";
 import About from "@/components/landing/About";
 import Features from "@/components/landing/Features";

--- a/components/blog/BlogCard.tsx
+++ b/components/blog/BlogCard.tsx
@@ -1,0 +1,81 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Calendar, User } from "lucide-react";
+
+type BlogCardProps = {
+    title: string;
+    slug: string;
+    coverImage?: string;
+    author?: string;
+    date?: string;      // ISO string is fine
+    excerpt?: string;
+};
+
+export default function BlogCard({
+    title,
+    slug,
+    coverImage,
+    author,
+    date,
+    excerpt,
+}: BlogCardProps) {
+    return (
+        <div className="rounded-xl overflow-hidden border bg-card shadow-sm hover:shadow-lg transition flex flex-col">
+            {/* feature image */}
+            <div className="relative aspect-[16/9] bg-muted">
+                {coverImage ? (
+                    <Image
+                        src={coverImage}
+                        alt={title}
+                        fill
+                        className="object-cover"
+                        sizes="(max-width:768px) 100vw, (max-width:1200px) 50vw, 33vw"
+                    />
+                ) : (
+                    <div className="absolute inset-0 grid place-items-center text-sm text-muted-foreground">
+                        No image
+                    </div>
+                )}
+            </div>
+
+            {/* body */}
+            <div className="p-4 flex-1 flex flex-col">
+                <Link href={`/blogs/${slug}`}>
+                    <h3 className="text-lg font-semibold hover:underline line-clamp-2">
+                        {title}
+                    </h3>
+                </Link>
+
+                <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                    {author && (
+                        <span className="inline-flex items-center gap-1">
+                            <User size={14} /> {author}
+                        </span>
+                    )}
+                    {date && (
+                        <span className="inline-flex items-center gap-1">
+                            <Calendar size={14} />
+                            {new Date(date).toLocaleDateString()}
+                        </span>
+                    )}
+                </div>
+
+                {excerpt && (
+                    <p className="mt-3 text-sm text-muted-foreground line-clamp-3 flex-1">
+                        {excerpt}
+                    </p>
+                )}
+
+                <Link
+                    href={`/blogs/${slug}`}
+                    className="mt-4 text-primary font-medium text-sm hover:underline"
+                >
+                    Read more →
+                </Link>
+            </div>
+        </div>
+    );
+}
+
+
+

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
   images: {
-    domains: ["img.youtube.com", "images.ctfassets.net"],
+    remotePatterns: [
+      { protocol: "https", hostname: "images.ctfassets.net" }, // Contentful
+      { protocol: "https", hostname: "img.youtube.com" },      // used elsewhere
+      { protocol: "https", hostname: "via.placeholder.com" },  // <-- add this for your dummy images
+    ],
   },
 };
 
 export default nextConfig;
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@clerk/nextjs": "^6.31.5",
+        "@clerk/nextjs": "^6.31.3",
         "@contentful/rich-text-react-renderer": "^16.1.0",
         "@fontsource/outfit": "^5.2.5",
         "@google/generative-ai": "^0.24.0",
@@ -39,7 +39,6 @@
         "class-variance-authority": "^0.7.1",
         "cloudinary": "^2.6.0",
         "clsx": "^2.1.1",
-        "cm6-theme-basic-dark": "^0.2.0",
         "contentful": "^11.7.15",
         "framer-motion": "^12.6.3",
         "libphonenumber-js": "^1.12.10",
@@ -6162,18 +6161,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/cm6-theme-basic-dark": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/cm6-theme-basic-dark/-/cm6-theme-basic-dark-0.2.0.tgz",
-      "integrity": "sha512-+mNNJecRtxS/KkloMDCQF0oTrT6aFGRZTjnBcdT5UG1pcDO4Brq8l1+0KR/8dZ7hub2gOGOzoi3rGFD8GzlH7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/highlight": "^1.0.0"
       }
     },
     "node_modules/cm6-theme-basic-light": {


### PR DESCRIPTION
…(#145)

### What does this PR do?
- Replaces basic list-style blogs page with a modern, responsive grid layout
- Introduces `BlogCard` component:
  - Feature image
  - Title
  - Author & publish date
  - Short excerpt
  - “Read more” link
- Cards stack in 1 column on mobile, 2–3 columns on larger screens
- Added fallback for missing images (placeholder support)

### Issue reference
Closes #145

### Files changed
- `app/(public)/blogs/page.tsx`
- `components/blog/BlogCard.tsx` (new)
- `next.config.ts`

### Screenshots
**Before:** 
<img width="1360" height="643" alt="483463716-9de04f52-b7ce-49e5-b0a0-1c3e083d0c6b" src="https://github.com/user-attachments/assets/a6c32327-092f-486a-9692-9f6491372b61" />

**After:**
<img width="1919" height="1079" alt="Screenshot 2025-08-30 001435" src="https://github.com/user-attachments/assets/6ffefcfe-67cc-4709-bfe6-cbb8f2cda005" />


### Test plan
- Run locally: `npm run dev`
- Visit `/blogs` → cards render with image/title/author/date/excerpt/CTA
- Check responsiveness: 1 col (mobile), 2 cols (sm), 3 cols (lg+)
- Click card → navigates to `/blogs/[slug]`

### Checklist
- [x] Tested locally on mobile, tablet, desktop
- [x] Responsive grid working
- [x] No build errors
- [x] Matches expected behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a unified Blog Card for posts, showing cover image, title, author, date, excerpt, and “Read more” links.
  - Updated the Blogs page to a responsive grid (1–3 columns) for improved browsing on mobile and desktop.

- Refactor
  - Replaced the previous post rendering with the new card-based layout; old markup removed from the UI.

- Chores
  - Expanded remote image support to ensure blog covers, thumbnails, and placeholders load reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->