### PR TITLE
feat(seo): add sitemap.xml and robots.txt for SEO (#144)

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+// app/robots.ts
+import { MetadataRoute } from "next";
+
+const BASE =
+    process.env.SITE_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    "http://localhost:3000";
+
+export default function robots(): MetadataRoute.Robots {
+    return {
+        rules: { userAgent: "*", allow: "/" },
+        sitemap: `${BASE}/sitemap.xml`,
+    };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,39 @@
+// app/sitemap.ts
+import { MetadataRoute } from "next";
+import { getAllBlogPosts } from "@/lib/blog";
+
+const BASE =
+    process.env.SITE_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    "http://localhost:3000";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+    // Static public routes
+    const staticPaths = [
+        "/",                // Home
+        "/about",
+        "/contributors",
+        "/blogs",
+        "/contact",
+        "/privacy-policy",
+        "/terms-of-use",
+    ];
+
+    const staticEntries: MetadataRoute.Sitemap = staticPaths.map((p) => ({
+        url: new URL(p, BASE).toString(),
+        lastModified: new Date(),
+        changeFrequency: "weekly",
+        priority: p === "/" ? 1 : 0.8,
+    }));
+
+    // Dynamic blog post routes
+    const posts = await getAllBlogPosts(); // returns BlogPost[] (slug, publishDate, etc.)
+    const blogEntries: MetadataRoute.Sitemap = posts.map((post) => ({
+        url: new URL(`/blogs/${post.slug}`, BASE).toString(),
+        lastModified: post.publishDate ? new Date(post.publishDate) : new Date(),
+        changeFrequency: "weekly",
+        priority: 0.9,
+    }));
+
+    return [...staticEntries, ...blogEntries];
+}


### PR DESCRIPTION
### What does this PR do?
- Implements `app/sitemap.ts` using Next.js Metadata routes
  - Includes static pages (Home, About, Contributors, Blogs, Contact, Privacy Policy, Terms)
  - Includes dynamic blog post routes from `getAllBlogPosts()`
  - Uses absolute URLs via `SITE_URL` (falls back to localhost for dev)
  - Sets sensible `lastModified`, `changeFrequency`, and `priority`
- Implements `app/robots.ts` pointing to `/sitemap.xml`

### Issue reference
Closes #144

### Test plan
- Run `npm run dev`
- Visit `/sitemap.xml` → static routes + blog posts listed
- Visit `/robots.txt` → references `Sitemap: <SITE_URL>/sitemap.xml`

### Notes
- `SITE_URL` is set in `.env` (`http://localhost:3000` for dev, `https://www.smriti.live` in production)
<img width="1919" height="944" alt="Screenshot 2025-08-31 230004" src="https://github.com/user-attachments/assets/01601691-3d47-4c7a-8bc4-5df0866a57fd" />
<img width="1919" height="945" alt="Screenshot 2025-08-31 230011" src="https://github.com/user-attachments/assets/3e49a7cf-6433-4b9d-add0-0351467d6e95" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a robots.txt endpoint that allows all crawlers and references the site’s sitemap.
  - Introduced an auto-generated sitemap including key pages and all blog posts, with last modified dates and update frequency to improve indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->