### PR TITLE
fix: prevent back-to-top button from overlapping footer

### DIFF
--- a/components/ui/BackToTopButton.tsx
+++ b/components/ui/BackToTopButton.tsx
@@ -6,6 +6,7 @@ import { ArrowUp } from "lucide-react";
 export default function BackToTopButton() {
   const [isVisible, setIsVisible] = useState(false);
   const [isScrolling, setIsScrolling] = useState(false);
+  const [shouldMoveUp, setShouldMoveUp] = useState(false);
 
   useEffect(() => {
     const toggleVisibility = () => {
@@ -14,6 +15,15 @@ export default function BackToTopButton() {
       } else {
         setIsVisible(false);
       }
+
+      // Check if we're near the bottom of the page
+      const windowHeight = window.innerHeight;
+      const documentHeight = document.documentElement.scrollHeight;
+      const scrollTop = window.scrollY;
+      const distanceFromBottom = documentHeight - (scrollTop + windowHeight);
+
+      // If we're within 100px of the bottom, move the button up
+      setShouldMoveUp(distanceFromBottom < 100);
     };
 
     window.addEventListener("scroll", toggleVisibility);
@@ -40,7 +50,7 @@ export default function BackToTopButton() {
       onClick={scrollToTop}
       disabled={isScrolling}
       className={`
-        fixed bottom-6 right-6 z-50 p-3 rounded-full shadow-xl
+        fixed right-6 z-50 p-3 rounded-full shadow-xl
         bg-gradient-to-r from-neutral-600 to-neutral-800 hover:from-neutral-700 hover:to-neutral-900
         text-white border-2 border-white/20
         transform transition-all duration-500 ease-out
@@ -51,6 +61,7 @@ export default function BackToTopButton() {
             : "opacity-0 translate-y-8 rotate-180 pointer-events-none"
         }
         ${isScrolling ? "animate-pulse" : ""}
+        ${shouldMoveUp ? "bottom-24" : "bottom-6"}
       `}
       aria-label="Back to Top"
     >


### PR DESCRIPTION
The back-to-top button was covering the footer text when scrolling to the bottom of the page. Now it automatically moves up when you get close to the footer so nothing gets hidden.

**What changed:**

1.Button moves up when you're near the bottom of the page
2.Smooth transition so it doesn't feel jarring
3.Everything else works exactly the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Back to Top button now dynamically shifts upward when the user nears the bottom of the page, reducing overlap with footers or sticky elements.
  * Position smoothly adjusts between two offsets based on scroll distance while preserving existing visibility and click-to-scroll behavior, ensuring a cleaner, unobstructed experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->