### PR TITLE
Added minimal WhatsApp reminder feature for #204

### DIFF
--- a/utils/remainder.js
+++ b/utils/remainder.js
@@ -1,0 +1,21 @@
+const twilio = require('twilio');
+const cron = require('node-cron');
+require('dotenv').config();
+
+const client = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
+
+const fromNumber = process.env.TWILIO_PHONE_NUMBER;
+const toNumber = 'whatsapp:+YOUR_NUMBER'; // replace with your personal WhatsApp number
+
+// Send a test reminder every minute
+cron.schedule('* * * * *', () => {
+  client.messages.create({
+    body: 'This is a test reminder from Smriti AI!',
+    from: fromNumber,
+    to: toNumber,
+  })
+  .then(message => console.log('Message sent:', message.sid))
+  .catch(err => console.error(err));
+});
+
+console.log('WhatsApp reminder service running...');


### PR DESCRIPTION
This PR adds a minimal WhatsApp reminder feature for the Smriti AI project (#204).

Features:
- Sends a test reminder message to the user via WhatsApp using Twilio Sandbox.
- Scheduled using `node-cron` to send messages at set intervals (currently every minute for testing purposes).
- Easy to extend for daily or topic-wise reminders in future.

Setup:
1. Add your Twilio Sandbox credentials to `.env.local`:
   TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER
2. Join the Twilio Sandbox on WhatsApp by sending `join sit-pan` to `+1 415 523 8886`.
3. Run `node utils/reminder.js` to test.

This is a minimal working version to demonstrate WhatsApp reminder functionality and can be extended further.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WhatsApp reminder service to send automated notifications to users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->